### PR TITLE
Make `--key` optional

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,29 +1,64 @@
 {-# LANGUAGE MultiWayIf        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE QuasiQuotes       #-}
 
 module Main where
 
+import qualified Control.Lens
 import           Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as C8L
+import qualified Data.Ini
 import           Data.Maybe
+import qualified Data.Text
 import qualified Data.Text.IO               as Text.IO
 import           Data.Thyme.Clock
+import qualified NeatInterpolation
 import           Options.Generic
+import qualified Turtle
+import           Turtle                     ((</>))
 
 import qualified Gen.AWS.SigKey             as SigKey
 
 main :: IO ()
 main = do
   SigKey.Options{..} <- unwrapRecord "Generate a AWS V4 scoped signing key"
-  now <- getCurrentTime
+
+  now  <- getCurrentTime
+
+  secretAccessKey <- case key of
+    Just secretAccessKey -> return secretAccessKey
+    Nothing              -> do
+      home <- Turtle.home
+      let credentialsFile = home </> ".aws" </> "credentials"
+      exists <- Turtle.testfile credentialsFile
+      if not exists
+        then fail (Data.Text.unpack [NeatInterpolation.text|
+Error: Cannot obtain secret access key
+
+If you do not provide the `--key` flag then there you must supply a credentials
+file at `~/.aws/credentials` instead
+|])
+        else do
+          text <- Turtle.readTextFile credentialsFile
+          let fold =
+                  Control.Lens._Right
+                . Control.Lens.to Data.Ini.unIni
+                . Control.Lens.ix "default"
+                . Control.Lens.ix "aws_secret_access_key"
+          case Control.Lens.preview fold (Data.Ini.parseIni text) of
+            Just secretAccessKey -> return secretAccessKey
+            Nothing -> fail (Data.Text.unpack [NeatInterpolation.text|
+Error: Could not decode the credentials file located at `~/.aws/credentials`
+|])
+
   let ssk@SigKey.ScopedSigningKey{..} =
         SigKey.makeKey
           now
           (fromMaybe "us-east-1" region)
           (fromMaybe "s3" service)
           (fromMaybe "aws4_request" protocol)
-          key
+          secretAccessKey
 
   if | sigonly   -> Text.IO.putStrLn signing_key
      | otherwise -> C8L.putStrLn $ encode ssk

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
-{ mkDerivation, aeson, base, bytestring, cryptonite, lens, memory
-, old-locale, optparse-generic, stdenv, tasty, tasty-golden
-, tasty-hunit, tasty-quickcheck, text, thyme
+{ mkDerivation, aeson, base, bytestring, cryptonite, ini, lens
+, memory, neat-interpolation, old-locale, optparse-generic, stdenv
+, tasty, tasty-golden, tasty-hunit, tasty-quickcheck, text, thyme
+, turtle
 }:
 mkDerivation {
   pname = "gen-aws-sigkey";
@@ -13,7 +14,8 @@ mkDerivation {
     text thyme
   ];
   executableHaskellDepends = [
-    aeson base bytestring lens optparse-generic text thyme
+    aeson base bytestring ini lens neat-interpolation optparse-generic
+    text thyme turtle
   ];
   testHaskellDepends = [
     base old-locale tasty tasty-golden tasty-hunit tasty-quickcheck

--- a/gen-aws-sigkey.cabal
+++ b/gen-aws-sigkey.cabal
@@ -41,10 +41,13 @@ executable gen-aws-sigkey
                 base
               , aeson
               , bytestring
+              , ini
               , lens
+              , neat-interpolation
               , optparse-generic
               , text
               , thyme
+              , turtle
               , gen-aws-sigkey
 
   default-language:    Haskell2010

--- a/src/Gen/AWS/SigKey/Types.hs
+++ b/src/Gen/AWS/SigKey/Types.hs
@@ -23,7 +23,7 @@ data Options w = Options
     <?> "AWS protocol [default: aws4_request]"
   , sigonly  :: w ::: Bool
     <?> "Print the signature only"
-  , key      :: w ::: Text
+  , key      :: w ::: Maybe Text
     <?> "AWS secret access key"
   } deriving (Generic)
 


### PR DESCRIPTION
This updates `gen-aws-sigkey` to be able to take the secret access key from
`~/.aws/credentials` instead of the command line

Really, the right thing to do would be to use a library like `amazonka` or `aws`
to obtain the credentials so that we could take advantage of multiple ways to
read credentials (like environment variables).

However, `aws-configuration-tools` flat out did not work and using `amazonka`
requires more extensive changes to this library since you cannot extract the
secret access key from the opaque `Auth` type